### PR TITLE
Fix Unicode bug, and make it Py2/Py3 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The first time you run this, it should open up a web browser, have you log into 
 2. Run the script like this to download your credentials: `python download_tweets_api.py --dist=tweeti-a.dist.tsv`
 3. Download tweets like so: 
 ```
-python download_tweets_api.py --dist=tweeti-a.dist.tsv > downloaded.tsv
+python download_tweets_api.py --dist=tweeti-a.dist.tsv --output=downloaded.tsv
 ```
 
 -Note that it takes about 18 hours to download the Semeval sentiment analysis training dataset.
@@ -31,7 +31,7 @@ In case the script hangs in the middle of the download for whatever reason, use 
 This way you won't have to start from scratch again:
 
 ```
-python download_tweets_api.py --dist=tweeti-a.dist.tsv --partial=downloaded.tsv > downloaded2.tsv
+python download_tweets_api.py --dist=tweeti-a.dist.tsv --partial=downloaded.tsv --output=downloaded2.tsv
 ```
 
 Task A Mention Test Script

--- a/download_tweets_api.py
+++ b/download_tweets_api.py
@@ -8,7 +8,8 @@ from twitter import *
 
 parser = argparse.ArgumentParser(description="downloads tweets")
 parser.add_argument('--partial', dest='partial', default=None, type=argparse.FileType('r'))
-parser.add_argument('--dist', dest='dist', default=None, type=argparse.FileType('r'), required=True)
+parser.add_argument('--dist', dest='dist', default=None, type=argparse.FileType('r', encoding='utf-8'), required=True)
+parser.add_argument('--output', dest='output', default=None, type=argparse.FileType('w', encoding='utf-8'), required=True)
 
 args = parser.parse_args()
 
@@ -34,7 +35,7 @@ for line in args.dist:
     sid = fields[0]
     uid = fields[1]
 
-    while not cache.has_key(sid):
+    while not sid in cache:
         try:
             text = t.statuses.show(_id=sid)['text'].replace('\n', ' ').replace('\r', ' ')
             cache[sid] = text
@@ -50,7 +51,7 @@ for line in args.dist:
                     time.sleep(seconds)
             else:
                 cache[sid] = 'Not Available'
-            
+
     text = cache[sid]
 
-    print "\t".join(fields + [text])
+    args.output.write("\t".join(fields + [text]) + '\n')


### PR DESCRIPTION
If you use the script as documented, it crashes the moment it receives a Unicode character from Twitter. This is because the script is written for Python 2, and you can't print Unicode in Python 2 when you're redirecting output with `>`.

I have fixed this problem on Python 2 by taking the name of the output file as an argument, and opening that file to be written as UTF-8.

I've also made the very small changes necessary to make the script run on Python 3 as well.
